### PR TITLE
feat: Implement initial phase of portfolio redesign

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,39 +27,30 @@
 						/>
 					</div>
 					<div class="profile-details">
-						<h1>Hello I'm Joseph Gitau</h1>
-						<div>JavaScript Developer</div>
+						<h1>Hello I’m Alex Morgan</h1>
+						<div>Web Designer, Content Creator & writer.</div>
 						<div>
-							<span></span>
+							<span></span> <!-- This span can be used for a status indicator icon if desired with CSS -->
 							<span>Available for work</span>
 						</div>
-						<div><span>P</span> <span>Nairobi, Kenya</span></div>
+						<div><span>Berlin, Germany</span></div> <!-- Removed the icon span, location text updated -->
 					</div>
 				</div>
 				<div>
 					<ul>
 						<li>
-							<span>E</span>
-							<a href="mailto:ts.gitaoh@gmail.com"
-								target="_blank">ts.gitaoh@gmail.com</a
-							>
+							<a href="#">InstantDesign.com</a>
 						</li>
 						<li>
-							<span>E</span>
-							<a href="tel:+254114544073">+254114544073</a>
+							<a href="tel:1356778820082">1356-77882-0082</a>
 						</li>
 						<li>
-							<span>E</span>
-							<a
-								href="https://x.com/tsgitaoh"
-								target="_blank"
-								>https://x.com/tsgitaoh</a
-							>
+							<a href="mailto:Instantcraft@Studio.in">Instantcraft@Studio.in</a>
 						</li>
 					</ul>
 					<div>
 						<button>Download CV</button>
-						<button>contact Me</button>
+						<button>Contact Me</button>
 					</div>
 				</div>
 			</section>
@@ -68,89 +59,88 @@
 					<h2>About</h2>
 					<article>
 						<p>
-							I am a software engineer with a passion for building
-							web applications. I have experience in JavaScript,
-							TypeScript, HTML, CSS, ReactJS, NextJS, and
-							TailwindCSS. I enjoy solving complex problems and
-							creating user-friendly interfaces. I am always eager
-							to learn new technologies and improve my skills. I
-							am currently looking for opportunities to work on
-							exciting projects and collaborate with talented
-							teams.
-						</p>
-						<p>
-							In my free time, I enjoy reading tech blogs,
-							contributing to open-source projects, and exploring
-							new frameworks and libraries. I believe in
-							continuous learning and strive to stay updated with
-							the latest trends in web development. I have a
-							strong foundation in web development principles and
-							best practices, and I am comfortable working with
-							both front-end and back-end technologies. I have
-							experience with RESTful APIs, version control
-							systems like Git, and agile development
-							methodologies. I am a quick learner and adapt easily
-							to new environments. I thrive in collaborative
-							settings and enjoy working with cross-functional
-							teams to deliver high-quality software solutions.
+							I am Alex Morgan, a passionate Web Designer & Developer residing in the
+							dynamic city of Berlin, Germany. My expertise lies at the intersection
+							of visual design and technical implementation.
+							With over 5 years of experience in creating visually stunning and
+							user-centric websites, I've honed my skills in both front-end and
+							back-end development.
 						</p>
 					</article>
 				</div>
 				<div>
 					<h2>Skills</h2>
 					<ul>
-						<li>Full-Stack Development</li>
+						<li>Web Design</li>
+						<li>UI/UX Design</li>
+						<li>Front-end development</li>
 						<li>Web Animations</li>
-						<li>MongoDB</li>
+						<li>Copywriting</li>
+						<li>Marketing</li>
 					</ul>
 				</div>
 				<div>
 					<h2>Experience</h2>
 					<article>
-						<h3>Software Engineer</h3>
-						<p>Company Name - Location</p>
-						<p>Dates of Employment</p>
-						<ul>
-							<li>
-								Developed and maintained web applications using
-								JavaScript, ReactJS, and Node.js.
-							</li>
-							<li>
-								Collaborated with cross-functional teams to
-								design and implement new features.
-							</li>
-							<li>
-								Participated in code reviews and contributed to
-								the improvement of development processes.
-							</li>
-						</ul>
+						<h3>Layers</h3>
+						<p class="role">Senior Web developer</p>
+						<p class="dates">Aug 24 - Present</p>
+					</article>
+					<article>
+						<h3>Catalog</h3>
+						<p class="role">Framer Developer</p>
+						<p class="dates">Sep 2023 - Aug 24</p>
+					</article>
+					<article>
+						<h3>Adorn Agency</h3>
+						<p class="role">Web designer</p>
+						<p class="dates">Aug 2023 - Sep 23</p>
 					</article>
 				</div>
 				<div>
 					<h2>Tech Stack</h2>
+					<ul>
+						<li>HTML</li>
+						<li>CSS</li>
+						<li>JavaScript</li>
+						<li>TypeScript</li>
+						<li>React</li>
+						<li>Node.js</li>
+					</ul>
 				</div>
 				<div>
 					<h2>Projects</h2>
-					<div>
-						<div>
-							<img
-								src="https://framerusercontent.com/images/a4rtk2ZVgHtbgx5p1V2Y3yp1B0.jpeg?scale-down-to=512"
-								alt=""
-							/>
-							<div>
-								<h3>Project Name</h3>
-								<p>
-									Description of the project and technologies
-									used.
-								</p>
-								<div>
-									<a
-										href="http://github.com"
-										target="_blank"
-										rel="noopener noreferrer"
-										>view</a
-									>
-								</div>
+					<div class="projects-grid">
+						<div class="project-card">
+							<img src="https://framerusercontent.com/images/a4rtk2ZVgHtbgx5p1V2Y3yp1B0.jpeg?scale-down-to=512" alt="Project Slate">
+							<div class="project-info">
+								<h3>Slate</h3>
+								<p>A sleek and responsive landing page designed for modern startups to showcase their products effectively.</p>
+								<a href="#">Click to view</a>
+							</div>
+						</div>
+						<div class="project-card">
+							<img src="https://framerusercontent.com/images/a4rtk2ZVgHtbgx5p1V2Y3yp1B0.jpeg?scale-down-to=512" alt="Project Antimetal">
+							<div class="project-info">
+								<h3>Antimetal</h3>
+								<p>A dynamic, animation-focused landing page highlighting creative transitions and interactive elements.</p>
+								<a href="#">Click to view</a>
+							</div>
+						</div>
+						<div class="project-card">
+							<img src="https://framerusercontent.com/images/a4rtk2ZVgHtbgx5p1V2Y3yp1B0.jpeg?scale-down-to=512" alt="Project Bankly">
+							<div class="project-info">
+								<h3>Bankly</h3>
+								<p>A customizable and developer-friendly starter kit for building high-performance landing pages with Next.js.</p>
+								<a href="#">Click to view</a>
+							</div>
+						</div>
+						<div class="project-card">
+							<img src="https://framerusercontent.com/images/a4rtk2ZVgHtbgx5p1V2Y3yp1B0.jpeg?scale-down-to=512" alt="Project Bentofy">
+							<div class="project-info">
+								<h3>Bentofy</h3>
+								<p>A visually appealing, multi-purpose landing page tailored for diverse business needs and tailored growth.</p>
+								<a href="#">Click to view</a>
 							</div>
 						</div>
 					</div>
@@ -158,9 +148,32 @@
 				<div>
 					<h2>Education</h2>
 					<article>
-						<h3>Bachelor of Science in Computer Science</h3>
-						<p>University Name - Location</p>
-						<p>Graduation Date</p>
+						<h3>Berlin State University</h3>
+						<p class="degree">Undergraduate in UI/UX</p>
+						<p class="dates">2021 - 2024</p>
+					</article>
+					<article>
+						<h3>GreenFields High school</h3>
+						<p class="degree">High school diploma</p>
+						<p class="dates">2018 - 2021</p>
+					</article>
+				</div>
+				<div>
+					<h2>Recognition</h2>
+					<article>
+						<h3>Best Web Designer</h3>
+						<p class="awarding-body">Awwwards</p>
+						<p class="year">2023</p>
+					</article>
+					<article>
+						<h3>Best animations awards</h3>
+						<p class="awarding-body">Framer Awards</p>
+						<p class="year">2020</p>
+					</article>
+					<article>
+						<h3>Top visual designer of the year</h3>
+						<p class="awarding-body">Awwwards</p>
+						<p class="year">2020</p>
 					</article>
 				</div>
 				<!-- <div>

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@
 body {
 	font-family: Arial, sans-serif;
 	background-color: rgb(246, 246, 246);
-	color: rgba(0, 0, 0, 0.74);
+	color: rgba(0, 0, 0, 0.8);
 }
 
 main {
@@ -26,24 +26,353 @@ main {
 
 .profile {
 	background-color: white;
-	/* border-radius: 10px; */
 	width: 100%;
 	display: flex;
+	align-items: center; /* Vertically align items */
+	gap: 20px; /* Space between image and details */
+	margin-bottom: 20px; /* Space below the profile block */
+}
+
+.profile-image { /* Applied to the div wrapping the image */
+	width: 100px;
+	height: 100px;
+	border-radius: 50%; /* Makes it circular */
+	overflow: hidden; /* Clips the image to the circle */
 }
 
 .profile-image img {
 	display: block;
-	width: 100px;
-	height: 100px;
-	border-radius: inherit;
+	width: 100%; /* Make image fill the circular div */
+	height: 100%; /* Make image fill the circular div */
+	object-fit: cover; /* Ensure image covers the area, cropping if necessary */
 	object-position: center center;
-	object-fit: cover;
 }
 
 .profile-details {
-	width: 100%;
+	/* width is already 100%, flex item will shrink if needed but take available space */
 }
 
+.profile-details h1 {
+	font-size: 2em;
+	font-weight: bold;
+	margin-bottom: 0.25em;
+	color: #333;
+}
+
+.profile-details div { /* General styling for title, availability, location */
+	margin-bottom: 0.5em;
+	font-size: 1em;
+	color: #555;
+}
+
+.profile-details div:nth-of-type(2) span:last-child { /* "Available for work" text */
+	color: #28a745; /* Green color */
+	font-weight: bold;
+}
+
+.profile-details div:nth-of-type(3) span { /* Location text */
+	font-size: 0.9em;
+	color: #777;
+}
+
+
+/* Contact List Styling */
+.details > div > ul {
+	list-style-type: none;
+	padding: 0;
+	margin: 20px 0;
+}
+
+.details > div > ul li {
+	margin-bottom: 8px;
+}
+
+.details > div > ul li a {
+	text-decoration: none;
+	color: #007bff; /* Bootstrap primary blue, common link color */
+}
+
+.details > div > ul li a:hover {
+	text-decoration: underline;
+}
+
+/* Buttons Container Styling */
+.details > div > div:last-child { /* Assuming this is the div wrapping buttons */
+	margin-top: 20px;
+	display: flex;
+	gap: 10px; /* Space between buttons */
+}
+
+/* General Button Styling */
+.details button {
+	padding: 12px 20px;
+	border: none;
+	border-radius: 6px;
+	cursor: pointer;
+	font-size: 0.95em;
+	font-weight: 500;
+	transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out;
+}
+
+/* "Download CV" Button */
+.details button:first-of-type {
+	background-color: #343a40; /* Dark gray */
+	color: white;
+}
+
+.details button:first-of-type:hover {
+	background-color: #23272b; /* Darken on hover */
+}
+
+/* "Contact Me" Button */
+.details button:last-of-type {
+	background-color: white;
+	color: #343a40; /* Dark gray */
+	border: 1px solid #343a40;
+}
+
+.details button:last-of-type:hover {
+	background-color: #f8f9fa; /* Light gray on hover */
+	color: #23272b;
+}
+
+
 .content {
-	display: none;
+	display: block;
+	padding-top: 20px; /* Add some padding at the top of the content area */
+}
+
+/* Styling for each direct div child within .content (each section) */
+.content > div {
+	margin-bottom: 40px; /* Space below each section (About, Skills, etc.) */
+}
+
+/* General styling for H2 headings within .content */
+.content h2 {
+	font-size: 1.8em;
+	font-weight: bold;
+	color: #333; /* Dark gray for headings */
+	margin-bottom: 15px;
+}
+
+/* Styling specifically for the paragraph in the "About" section */
+/* Assumes "About" is the first div inside .content */
+.content > div:first-child article p {
+	font-size: 1em; /* Standard paragraph font size */
+	line-height: 1.7; /* Improved line spacing for readability */
+	color: #555; /* Slightly lighter than headings for body text */
+}
+
+/* General styling for paragraphs within .content articles (can be expanded) */
+.content article p {
+	font-size: 1em;
+	line-height: 1.7;
+	color: #555;
+	margin-bottom: 1em; /* Space between paragraphs if there are multiple */
+}
+
+.content article p:last-child {
+	margin-bottom: 0; /* No margin for the last paragraph in an article */
+}
+
+/* General styling for lists within .content (e.g., Skills section) */
+.content ul {
+	list-style-position: inside; /* If using list-style-type */
+	padding-left: 0; /* Reset padding if custom styling list items */
+	color: #555;
+	line-height: 1.7;
+	/* margin-bottom is already handled by .content > div */
+}
+
+.content ul li {
+	margin-bottom: 0.5em; /* Space between list items */
+}
+
+/* Specific styling for the Skills section list */
+/* Assumes "Skills" is the second div inside .content */
+.content > div:nth-child(2) ul {
+	display: flex;
+	flex-wrap: wrap; /* Allow items to wrap to the next line */
+	gap: 10px; /* Spacing between skill tags */
+	list-style-type: none; /* Remove bullets */
+	padding-left: 0; /* Ensure no default padding */
+	line-height: normal; /* Reset line-height from general ul style */
+	/* color will be inherited or set by li */
+}
+
+/* Specific styling for individual skill items (tags) */
+.content > div:nth-child(2) ul li {
+	background-color: #e9ecef; /* Light grey background */
+	color: #333; /* Dark text color */
+	padding: 8px 12px; /* Padding inside each tag */
+	border-radius: 4px; /* Rounded corners for tags */
+	margin-bottom: 0; /* Override general li margin, gap handles spacing */
+	font-size: 0.9em; /* Slightly smaller font for tags */
+}
+
+/* Specific styling for the Experience section */
+/* Assumes "Experience" is the third div inside .content */
+.content > div:nth-child(3) article {
+	margin-bottom: 25px; /* Space between job entries */
+}
+
+.content > div:nth-child(3) article:last-of-type {
+	margin-bottom: 0; /* No bottom margin for the last job entry in the list */
+}
+
+.content > div:nth-child(3) article h3 {
+	font-size: 1.25em; /* Company name font size */
+	font-weight: bold;
+	color: #333;
+	margin-bottom: 5px; /* Space below company name */
+}
+
+.content > div:nth-child(3) article p.role {
+	font-size: 1em; /* Role font size */
+	color: #555;
+	margin-bottom: 3px; /* Space below role */
+	line-height: 1.4; /* Adjusted line height */
+}
+
+/* Specific styling for the Recognition section */
+/* Assumes "Recognition" is the seventh div inside .content */
+.content > div:nth-child(7) article {
+	margin-bottom: 25px; /* Space between recognition entries */
+}
+
+.content > div:nth-child(7) article:last-of-type {
+	margin-bottom: 0; /* No bottom margin for the last recognition entry */
+}
+
+.content > div:nth-child(7) article h3 {
+	font-size: 1.25em; /* Award name font size */
+	font-weight: bold;
+	color: #333;
+	margin-bottom: 5px; /* Space below award name */
+}
+
+.content > div:nth-child(7) article p.awarding-body {
+	font-size: 1em; /* Awarding body font size */
+	color: #555;
+	margin-bottom: 3px; /* Space below awarding body */
+	line-height: 1.4; /* Adjusted line height */
+}
+
+.content > div:nth-child(7) article p.year {
+	font-size: 0.9em; /* Year font size */
+	color: #777;
+	margin-bottom: 0; /* No space below year */
+	line-height: 1.4; /* Adjusted line height */
+}
+
+/* Specific styling for the Education section */
+/* Assumes "Education" is the sixth div inside .content */
+.content > div:nth-child(6) article {
+	margin-bottom: 25px; /* Space between education entries */
+}
+
+.content > div:nth-child(6) article:last-of-type {
+	margin-bottom: 0; /* No bottom margin for the last education entry */
+}
+
+.content > div:nth-child(6) article h3 {
+	font-size: 1.25em; /* Institution name font size */
+	font-weight: bold;
+	color: #333;
+	margin-bottom: 5px; /* Space below institution name */
+}
+
+.content > div:nth-child(6) article p.degree {
+	font-size: 1em; /* Degree font size */
+	color: #555;
+	margin-bottom: 3px; /* Space below degree */
+	line-height: 1.4; /* Adjusted line height */
+}
+
+.content > div:nth-child(6) article p.dates {
+	font-size: 0.9em; /* Dates font size */
+	color: #777;
+	margin-bottom: 0; /* No space below dates */
+	line-height: 1.4; /* Adjusted line height */
+}
+
+/* Specific styling for the Projects section */
+/* Assumes "Projects" is the fifth div inside .content */
+.content > div:nth-child(5) .projects-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+	gap: 20px;
+}
+
+.content > div:nth-child(5) .project-card {
+	background-color: #ffffff;
+	border: 1px solid #e0e0e0;
+	border-radius: 8px;
+	overflow: hidden;
+	box-shadow: 0 2px 5px rgba(0,0,0,0.05);
+}
+
+.content > div:nth-child(5) .project-card img {
+	width: 100%;
+	height: 200px;
+	object-fit: cover;
+	display: block;
+}
+
+.content > div:nth-child(5) .project-card .project-info {
+	padding: 15px;
+}
+
+.content > div:nth-child(5) .project-card .project-info h3 {
+	font-size: 1.2em;
+	font-weight: bold;
+	margin-bottom: 10px;
+	color: #333;
+}
+
+/* Override general article p styles for project card descriptions */
+.content > div:nth-child(5) .project-card .project-info p {
+	font-size: 0.9em;
+	color: #666;
+	margin-bottom: 15px;
+	line-height: 1.5; /* Specific line height for project descriptions */
+}
+
+.content > div:nth-child(5) .project-card .project-info a {
+	color: #007bff;
+	text-decoration: none;
+	font-weight: bold;
+	display: inline-block;
+}
+
+.content > div:nth-child(5) .project-card .project-info a:hover {
+	text-decoration: underline;
+}
+
+/* Specific styling for the Tech Stack section list */
+/* Assumes "Tech Stack" is the fourth div inside .content */
+.content > div:nth-child(4) ul {
+	display: flex;
+	flex-wrap: wrap; /* Allow items to wrap to the next line */
+	gap: 10px; /* Spacing between tech stack tags */
+	list-style-type: none; /* Remove bullets */
+	padding-left: 0; /* Ensure no default padding */
+	line-height: normal; /* Reset line-height from general ul style */
+}
+
+/* Specific styling for individual tech stack items (tags) */
+.content > div:nth-child(4) ul li {
+	background-color: #e9ecef; /* Light grey background */
+	color: #333; /* Dark text color */
+	padding: 8px 12px; /* Padding inside each tag */
+	border-radius: 4px; /* Rounded corners for tags */
+	margin-bottom: 0; /* Override general li margin, gap handles spacing */
+	font-size: 0.9em; /* Slightly smaller font for tags */
+}
+
+.content > div:nth-child(3) article p.dates {
+	font-size: 0.9em; /* Dates font size */
+	color: #777;
+	margin-bottom: 0; /* No space below dates */
+	line-height: 1.4; /* Adjusted line height */
 }


### PR DESCRIPTION
This commit implements the initial redesign of the portfolio page to match the look and feel of monocv.framer.website.

Changes include:

1.  **Basic Structure and Visibility:**
    *   Made the main content section visible.
    *   Applied global styles (font, background, text color).

2.  **Profile Section:**
    *   Updated HTML to match target content (name, title, availability, location, contacts).
    *   Styled the profile section with Flexbox layout, typography, and button styles.

3.  **"About" Section:**
    *   Updated content in `index.html`.
    *   Styled with appropriate typography and spacing.

4.  **"Skills" Section:**
    *   Updated skills list in `index.html`.
    *   Styled skills as tag-like elements using Flexbox.

5.  **"Experience" Section:**
    *   Restructured HTML for multiple job entries.
    *   Styled entries with consistent typography and spacing.

6.  **"Tech Stack" Section:**
    *   Added placeholder technologies to `index.html`.
    *   Styled items as tag-like elements, similar to "Skills".

7.  **"Projects" Section:**
    *   Implemented a 4-project grid layout in `index.html`.
    *   Styled project cards with images, titles, descriptions, and links.

8.  **"Education" Section:**
    *   Updated HTML for multiple education entries.
    *   Styled entries consistently with "Experience".

9.  **"Recognition" Section:**
    *   Added a new section to `index.html` for awards.
    *   Styled entries consistently with "Experience" and "Education".

The overall structure of the content area has been established with distinct sections for profile information, about, skills, experience, tech stack, projects, education, and recognition. Styling for these sections, including typography, layout, and spacing, has been applied to closely resemble the target design.

Further steps include adding "Recommendations", "Links", styling the "Contact Me" form, and adding a footer.